### PR TITLE
fix plotting in python 2

### DIFF
--- a/calibrate_cams.py
+++ b/calibrate_cams.py
@@ -184,7 +184,7 @@ def get_all_linear_pots(cams):
 def load_data_from_file(fn, line):
     'Import a shell script which stores cam calibration data'
     with open(fn, 'rt') as f:
-        lines = [line.strip() for line in f.readlines()]
+        lines = [lin.strip() for lin in f.readlines()]
 
     data = {'linear': {},
             'calibration': {}}


### PR DESCRIPTION
Edited line 187. Renamed local variable 'line' so that it does not conflict with the 'line' function argument. In pyton 2 the value passed as a function argument was being overwritten.